### PR TITLE
Feature: Support for src_folders which are inside of node_modules

### DIFF
--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -50,8 +50,22 @@ ChildProcess.prototype.run = function(colors, done) {
     env.__NIGHTWATCH_ENV_KEY = self.itemKey;
     env.__NIGHTWATCH_ENV_LABEL = self.env_itemKey;
 
+    var testCWD = process.cwd();
+    var testFilePath = self.args[self.args.length - 2];
+
+    /*
+    * Require the file in the right cwd to ensure it doesn't error
+    */
+    if (testFilePath.indexOf('node_modules') > -1) {
+      var paths = testFilePath.split('/');
+      testCWD = paths.splice(0, paths.indexOf('node_modules') + 2).join('/');
+      if (self.settings.output) {
+        console.log('This test will use its own cwd:', testCWD);
+      }
+    }
+
     self.child = child_process.spawn(process.execPath, cliArgs, {
-      cwd: process.cwd(),
+      cwd: testCWD,
       encoding: 'utf8',
       env: env,
       stdio: [null, null, null, 'ipc']
@@ -64,7 +78,7 @@ ChildProcess.prototype.run = function(colors, done) {
     self.processRunning = true;
 
     if (self.settings.output) {
-      console.log('Started child process for:' + self.env_label);
+      console.log('  Started child process for:' + self.env_label);
     }
 
     self.child.stdout.on('data', function (data) {

--- a/lib/runner/filematcher.js
+++ b/lib/runner/filematcher.js
@@ -23,6 +23,8 @@ function matchFilePath(filePath, pathArr) {
   return false;
 }
 
+var originalCWD = process.cwd();
+
 module.exports = {
   tags: {
     /**
@@ -31,7 +33,17 @@ module.exports = {
      * @returns {boolean} true if specified test matches given tag
      */
     match : function (testFilePath, opts) {
+      /*
+       * Require the file in the right cwd to ensure it doesnt error
+       */
+      if (testFilePath.indexOf('node_modules') > -1) {
+        var paths = testFilePath.split('/');
+        var testCWD = paths.splice(0, paths.indexOf('node_modules') + 2).join('/');
+        process.chdir(testCWD);
+      }
+
       var test = require(testFilePath);
+      process.chdir(originalCWD);
       return this.checkModuleTags(test, opts);
     },
 

--- a/lib/runner/module.js
+++ b/lib/runner/module.js
@@ -1,10 +1,22 @@
 var path = require('path');
 var Utils = require('../util/utils.js');
 
+var originalCWD = process.cwd();
+
 function Module(modulePath, opts, addtOpts) {
+  /*
+   * Require the file in the right cwd to ensure it has access
+   * to its own dependancies
+   */
+  if (modulePath.indexOf('node_modules') > -1) {
+    var paths = modulePath.split('/');
+    var testCWD = paths.splice(0, paths.indexOf('node_modules') + 2).join('/');
+    process.chdir(testCWD);
+  }
 
   try {
     this['@module'] = require(modulePath);
+    process.chdir(originalCWD);
   } catch (err) {
     throw err;
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mocha-lcov-reporter": "^1.2.0",
     "mock-spawn": "^0.2.1",
     "mockery": "~1.4.0",
+    "nightwatch-component-a": "git://github.com/cesine/nightwatch-component-a",
     "nock": "~0.45.0"
   },
   "bin": {

--- a/test/nightwatch.json
+++ b/test/nightwatch.json
@@ -1,5 +1,8 @@
 {
-  "src_folders" : ["./test/src"],
+  "src_folders" : [
+    "./test/src",
+    "./node_modules/nightwatch-component-a/test"
+  ],
   "test_workers" : false,
   "selenium" : {
     "start_process" : false,


### PR DESCRIPTION
We have a project which is running the tests of several other projects which npm installed and contain web components that we want to test both in their own context and in other contexts. Our config:

```
"src_folders": [
    "test",
    "../../node_modules/bar/test",
    "../../node_modules/baz/test",
  ],
```

When we switched to NPM3 we kept getting `nightwatch exited with code 1` after looking into it using #, we found it was because our tests in `bar` were unable to load their dependancies because the cwd was where the tests were run from so require couldn't resolve the deps. 

 When running the tests with `src_folders` which point to the other projects in node_modules, we found that the tests were unable to load config and other things which depend on the location of the pwd where the test is running. 

I was able confirm this was the source of failures by setting the cwd of the child processes to the root of the installed projects eg `bar`, so the `bar` tests are able to load their own dependancies etc. 

- [ ] reliable way to get the cwd from args
- [ ] tests added (I'll do this later once i know more about how the examples and test are related)
